### PR TITLE
Treat Container Cmd parameter as a [String]

### DIFF
--- a/src/modules/container/resolvers/container-config.resolver.ts
+++ b/src/modules/container/resolvers/container-config.resolver.ts
@@ -23,5 +23,6 @@ export default ({ config }: GraphQLModule<ContainerModuleConfig>) => ({
     image: async c => await config.docker.image.get(c.Image),
     workingDir: c => c.WorkingDir,
     entrypoint: c => Array.isArray(c.Entrypoint) ? c.Entrypoint : [c.Entrypoint],
+    cmd: c => Array.isArray(c.Cmd) ? c.Cmd : [c.Cmd],
   },
 });

--- a/src/modules/container/resolvers/mutation.resolver.ts
+++ b/src/modules/container/resolvers/mutation.resolver.ts
@@ -1,31 +1,13 @@
 import { GraphQLModule } from '@graphql-modules/core';
 import { ContainerModuleConfig } from '..';
 
-function parseArgsStringToArgv(value) {
-  let myRegexp = /([^\s'"]+(['"])([^\2]*?)\2)|[^\s'"]+|(['"])([^\4]*?)\4/gi;
-  let myString = value;
-  let myArray = [];
-  let match: any;
-
-  do {
-    match = myRegexp.exec(myString);
-    if (match !== null) {
-      myArray.push(match[1] || match[5] || match[0]);
-    }
-  } while (match !== null);
-
-  return myArray;
-}
-
 export default ({ config }: GraphQLModule<ContainerModuleConfig>) => ({
   Mutation: {
     create: async (root: never, { options }) => {
-      const parsedCmd = options.cmd ? parseArgsStringToArgv(options.cmd) : [];
-
       const container = await config.docker.container.create({
         Image: options.image,
         name: options.name,
-        Cmd: parsedCmd,
+        Cmd: options.cmd,
         Env: options.env ? options.env.map(env => `${env.name}=${env.value}`) : [],
         Labels: options.labels ? options.labels.reduce((acc, label) => ({...acc, [label.name]: label.value}), {}) : {}
       });

--- a/src/modules/container/schema/container.graphql
+++ b/src/modules/container/schema/container.graphql
@@ -23,6 +23,7 @@ type ContainerConfig {
   image: Image!
   workingDir: String
   entrypoint: [String]
+  cmd: [String]
 }
 
 type ContainerEnvVar {

--- a/src/modules/container/schema/mutation.graphql
+++ b/src/modules/container/schema/mutation.graphql
@@ -9,7 +9,7 @@ type Mutation {
 input CreateContainerOptions {
   image: String!
   name: String
-  cmd: String
+  cmd: [String]
   start: Boolean
   env: [EnvVariable]
   labels: [Label]


### PR DESCRIPTION
I figured it probably makes sense to treat the `Cmd` parameter like the `Entrypoint`  #2, both can be either `string` or `string[]`.